### PR TITLE
Add more context of EduBase Quiz hierarchy to descriptions

### DIFF
--- a/dist/tools/exams.js
+++ b/dist/tools/exams.js
@@ -17,7 +17,7 @@ export const EDUBASE_API_TOOLS_EXAMS = [
     // GET /exams - List owned and managed exams
     {
         name: 'edubase_get_exams',
-        description: "List owned and managed exams.",
+        description: "List owned and managed exams. Exams are the highest level in the EduBase Quiz hierarchy, built from Quiz sets.",
         inputSchema: {
             type: 'object',
             properties: {
@@ -55,7 +55,7 @@ export const EDUBASE_API_TOOLS_EXAMS = [
     // POST /exam - Create a new exam from an existing Quiz set
     {
         name: 'edubase_post_exam',
-        description: "Create a new exam from an existing Quiz set. Note: Exams MUST be created from existing Quiz sets as per the EduBase hierarchical structure.",
+        description: "Create a new exam from an existing Quiz set. Exams are at the top level of the EduBase Quiz hierarchy and MUST be created from existing Quiz sets. They are time-constrained, secured assessment instances of Quiz sets.",
         inputSchema: {
             type: 'object',
             properties: {

--- a/dist/tools/questions.js
+++ b/dist/tools/questions.js
@@ -16,7 +16,7 @@ export const EDUBASE_API_TOOLS_QUESTIONS = [
     // GET /question - Check existing question
     {
         name: 'edubase_get_question',
-        description: "Check existing question.",
+        description: "Check existing question. Questions are the lowest level in the EduBase hierarchy, serving as the building blocks for Quiz sets.",
         inputSchema: {
             type: 'object',
             properties: {
@@ -31,7 +31,7 @@ export const EDUBASE_API_TOOLS_QUESTIONS = [
     // POST /question - Publish or update a question
     {
         name: 'edubase_post_question',
-        description: "Publish or update a question.",
+        description: "Publish or update a question. Questions are the atomic building blocks of the EduBase Quiz system and represent the lowest level in the hierarchy (Questions -> Quiz sets -> Exams).",
         inputSchema: {
             type: 'object',
             properties: {

--- a/dist/tools/quizes.js
+++ b/dist/tools/quizes.js
@@ -15,7 +15,7 @@ export const EDUBASE_API_TOOLS_QUIZES = [
     // GET /quizes - List owned and managed Quiz sets
     {
         name: 'edubase_get_quizes',
-        description: "List owned and managed Quiz sets.",
+        description: "List owned and managed Quiz sets. Quiz sets are named collections of questions that sit at the middle level of the EduBase Quiz hierarchy.",
         inputSchema: {
             type: 'object',
             properties: {
@@ -38,7 +38,7 @@ export const EDUBASE_API_TOOLS_QUIZES = [
     // GET /quiz - Get/check Quiz set
     {
         name: 'edubase_get_quiz',
-        description: "Get/check Quiz set.",
+        description: "Get/check Quiz set. Containing questions and powering Exams.",
         inputSchema: {
             type: 'object',
             properties: {
@@ -53,7 +53,7 @@ export const EDUBASE_API_TOOLS_QUIZES = [
     // POST /quiz - Create a new Quiz set
     {
         name: 'edubase_post_quiz',
-        description: "Create a new Quiz set",
+        description: "Create a new Quiz set. Quiz sets are collections of questions that can be used for practice or to power multiple Exams.",
         inputSchema: {
             type: 'object',
             properties: {
@@ -104,7 +104,7 @@ export const EDUBASE_API_TOOLS_QUIZES = [
     // GET /quiz:questions - List all questions and question groups in a Quiz set
     {
         name: 'edubase_get_quiz_questions',
-        description: "List all questions and question groups in a Quiz set.",
+        description: "List all questions and question groups in a Quiz set. Quiz sets contain questions (lowest level) and can be used by exams (highest level).",
         inputSchema: {
             type: 'object',
             properties: {
@@ -119,7 +119,7 @@ export const EDUBASE_API_TOOLS_QUIZES = [
     // POST /quiz:questions - Assign question(s) to a Quiz set, or one of its question group
     {
         name: 'edubase_post_quiz_questions',
-        description: "Assign question(s) to a Quiz set, or one of its question group.",
+        description: "Assign question(s) to a Quiz set, or one of its question group. Questions can exist independently from Quiz sets.",
         inputSchema: {
             type: 'object',
             properties: {

--- a/src/tools/exams.ts
+++ b/src/tools/exams.ts
@@ -20,7 +20,7 @@ export const EDUBASE_API_TOOLS_EXAMS: Tool[] = [
 	// GET /exams - List owned and managed exams
 	{
 		name: 'edubase_get_exams',
-		description: "List owned and managed exams.",
+		description: "List owned and managed exams. Exams are the highest level in the EduBase Quiz hierarchy, built from Quiz sets.",
 		inputSchema: {
 			type: 'object',
 			properties: {
@@ -60,7 +60,7 @@ export const EDUBASE_API_TOOLS_EXAMS: Tool[] = [
 	// POST /exam - Create a new exam from an existing Quiz set
 	{
 		name: 'edubase_post_exam',
-		description: "Create a new exam from an existing Quiz set. Note: Exams MUST be created from existing Quiz sets as per the EduBase hierarchical structure.",
+		description: "Create a new exam from an existing Quiz set. Exams are at the top level of the EduBase Quiz hierarchy and MUST be created from existing Quiz sets. They are time-constrained, secured assessment instances of Quiz sets.",
 		inputSchema: {
 			type: 'object',
 			properties: {

--- a/src/tools/questions.ts
+++ b/src/tools/questions.ts
@@ -19,7 +19,7 @@ export const EDUBASE_API_TOOLS_QUESTIONS: Tool[] = [
 	// GET /question - Check existing question
 	{
 		name: 'edubase_get_question',
-		description: "Check existing question.",
+		description: "Check existing question. Questions are the lowest level in the EduBase hierarchy, serving as the building blocks for Quiz sets.",
 		inputSchema: {
 			type: 'object',
 			properties: {
@@ -35,7 +35,7 @@ export const EDUBASE_API_TOOLS_QUESTIONS: Tool[] = [
 	// POST /question - Publish or update a question
 	{
 		name: 'edubase_post_question',
-		description: "Publish or update a question.",
+		description: "Publish or update a question. Questions are the atomic building blocks of the EduBase Quiz system and represent the lowest level in the hierarchy (Questions -> Quiz sets -> Exams).",
 		inputSchema: {
 			type: 'object',
 			properties: {

--- a/src/tools/quizes.ts
+++ b/src/tools/quizes.ts
@@ -18,7 +18,7 @@ export const EDUBASE_API_TOOLS_QUIZES: Tool[] = [
 	// GET /quizes - List owned and managed Quiz sets
 	{
 		name: 'edubase_get_quizes',
-		description: "List owned and managed Quiz sets.",
+		description: "List owned and managed Quiz sets. Quiz sets are named collections of questions that sit at the middle level of the EduBase Quiz hierarchy.",
 		inputSchema: {
 			type: 'object',
 			properties: {
@@ -42,7 +42,7 @@ export const EDUBASE_API_TOOLS_QUIZES: Tool[] = [
 	// GET /quiz - Get/check Quiz set
 	{
 		name: 'edubase_get_quiz',
-		description: "Get/check Quiz set.",
+		description: "Get/check Quiz set. Containing questions and powering Exams.",
 		inputSchema: {
 			type: 'object',
 			properties: {
@@ -58,7 +58,7 @@ export const EDUBASE_API_TOOLS_QUIZES: Tool[] = [
 	// POST /quiz - Create a new Quiz set
 	{
 		name: 'edubase_post_quiz',
-		description: "Create a new Quiz set",
+		description: "Create a new Quiz set. Quiz sets are collections of questions that can be used for practice or to power multiple Exams.",
 		inputSchema: {
 			type: 'object',
 			properties: {
@@ -113,7 +113,7 @@ export const EDUBASE_API_TOOLS_QUIZES: Tool[] = [
 	// GET /quiz:questions - List all questions and question groups in a Quiz set
 	{
 		name: 'edubase_get_quiz_questions',
-		description: "List all questions and question groups in a Quiz set.",
+		description: "List all questions and question groups in a Quiz set. Quiz sets contain questions (lowest level) and can be used by exams (highest level).",
 		inputSchema: {
 			type: 'object',
 			properties: {
@@ -129,7 +129,7 @@ export const EDUBASE_API_TOOLS_QUIZES: Tool[] = [
 	// POST /quiz:questions - Assign question(s) to a Quiz set, or one of its question group
 	{
 		name: 'edubase_post_quiz_questions',
-		description: "Assign question(s) to a Quiz set, or one of its question group.",
+		description: "Assign question(s) to a Quiz set, or one of its question group. Questions can exist independently from Quiz sets.",
 		inputSchema: {
 			type: 'object',
 			properties: {


### PR DESCRIPTION
Feel free to edit these descriptions, but I thought it would be useful to have this in the descriptions as well. (Will be visible to the user on the Claude Desktop app, I know.)